### PR TITLE
fix(help): Was displaying "\" explicitly, fix(formatting): Fixed a bunch of formatting

### DIFF
--- a/ergonomica.py
+++ b/ergonomica.py
@@ -73,7 +73,7 @@ sys.path.append("lib")
 from prompt_toolkit import prompt
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.completion import Completer
-#from prompt_toolkit.layout.lexers import PygmentsLexer
+# from prompt_toolkit.layout.lexers import PygmentsLexer
 sys.path.append("..")
 
 # set terminal title
@@ -83,7 +83,7 @@ sys.stdout.write("\x1b]2;ergonomica\x07")
 ENV = Environment()
 ENV.verbs = verbs
 
-#if ENV.editor_mode:
+# if ENV.editor_mode:
 #    if _readline:
 #        readline.parse_and_bind('set editing-mode %s' % (ENV.editor_mode))
 
@@ -99,6 +99,8 @@ verbs["load_config"](ENV, [], [])
 debug = []
 
 # choose unicode/str based on python version
+
+
 def unicode_(PROMPT):
     if sys.version_info[0] >= 3:
         return str(PROMPT)
@@ -208,7 +210,7 @@ def ergo(stdin, depth=0):
                         func = get_func(tokenized_blocks[i], verbs)
                         args, kwargs = get_args_kwargs(tokenized_blocks[i], pipe)
                         stdout = func(ENV, args, kwargs)
-                    except KeyError as error: #not in ergonomica path
+                    except KeyError as error:  # not in ergonomica path
                         if not str(handle_runtime_error(blocks[i], error)).startswith("[ergo: CommandError]"):
                             raise error
                         try:
@@ -219,7 +221,7 @@ def ergo(stdin, depth=0):
             # filter out none values
             try:
                 if isinstance(stdout, list):
-                    stdout = [x for x in stdout if x != None]
+                    stdout = [x for x in stdout if x is not None]
             except TypeError:
                 stdout = []
 
@@ -230,6 +232,7 @@ def ergo(stdin, depth=0):
         handled_stdout = handle_stdout(stdout, pipe, num_blocks)
         if handled_stdout is not None:
             return handled_stdout
+
 
 def print_ergo(stdin):
     """Print the result of ergo(stdin) properly."""

--- a/lib/globalization/globalization/EN/help_welcome_message
+++ b/lib/globalization/globalization/EN/help_welcome_message
@@ -1,5 +1,4 @@
-Welcome to the Ergonomica Help System! What would you like he\
-lp with?
+Welcome to the Ergonomica Help System! What would you like help with?
 
    help syntax      - print introduction and syntax for ergonomica
    help commands    - print all commands and their docstrings

--- a/lib/interface/completer.py
+++ b/lib/interface/completer.py
@@ -23,7 +23,7 @@ def complete(verbs, text):
         else:
             dirname = os.path.dirname(text.split(" ")[1])
             original_dirname = dirname
-            
+
             # process dirname
             if not dirname.startswith("/"):
                 if dirname.startswith("~"):
@@ -48,18 +48,19 @@ def complete(verbs, text):
         return [(len(last_word), i) for i in options]
     return ""
 
+
 class ErgonomicaCompleter(Completer):
 
     verbs = {}
-    
+
     def __init__(self, verbs):
         self.verbs = verbs
-    
+
     def get_completions(self, document, complete_event):
         for result in complete(self.verbs, document.text):
-            
+
             start_point = result[0]
-            
+
             # check if there's a space that needs to be escaped
             if " " in result[1]:
                 # TODO: make this work when autocomplete is completing something with a double quote


### PR DESCRIPTION
Help message was printing "\\" newline escape explicitly, I just removed
the "\\" in the help file and put it on the same line to fix this. It
wasn't exceeding 80 characters anyways.