### PR TITLE
Add 'exit' alias to quit for convenience

### DIFF
--- a/ergonomica/lib/lib/ergo_exit.py
+++ b/ergonomica/lib/lib/ergo_exit.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""
+[lib/lib/ergo_exit.py]
+
+Defines the "quit" command.
+"""
+
+
+def main(args):
+    """exit: Exit the Ergonomica shell.
+
+    Usage:
+       exit
+    """
+
+    args.env.run = False


### PR DESCRIPTION
Given that each REPL seems to have their own preference of 'quit' vs 'exit', supporting both (as Bash does) reduces significant frustration.