### PR TITLE
Compatibility with prompt_toolkit 2.0

### DIFF
--- a/ergonomica/lib/interface/prompt.py
+++ b/ergonomica/lib/interface/prompt.py
@@ -17,9 +17,8 @@ import prompt_toolkit
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from ergonomica.lib.interface.completer import ErgonomicaCompleter
-from ergonomica.lib.interface.key_bindings_manager import manager_for_environment
-from prompt_toolkit.styles import style_from_dict
-from prompt_toolkit.token import Token
+from ergonomica.lib.interface.key_bindings_manager import load_key_bindings
+from prompt_toolkit.styles import Style
 
 try:
     HISTORY = FileHistory(os.path.join(os.path.expanduser("~"), ".ergo", ".ergo_history"))
@@ -29,24 +28,17 @@ except IOError as error:
           file=sys.stderr)
 
 
-def get_bottom_toolbar_tokens(cli):
-    return [(prompt_toolkit.Token.Toolbar, ' This is a toolbar. ')]
-
-
-def get_rprompt_tokens(cli):
-    return [(prompt_toolkit.Token, ' '), (prompt_toolkit.Token.RPrompt, '<rprompt>')]
-
-
-style = prompt_toolkit.styles.style_from_dict({
-    Token.RPrompt: 'bg:#ff0066 #ffffff',
-    Token.Toolbar: '#ffffff bg:#333333',
+style = Style.from_dict({
+    'rprompt': 'bg:#ff0066 #ffffff',
+    'toolbar': '#ffffff bg:#333333',
 })
 
 
 # this is the standard (namespace is ns) elsewhere
 def prompt(env, ns): # pylint: disable=invalid-name
     """Get input from prompt_toolkit prompt."""
-    key_bindings_registry = manager_for_environment(env).registry
+    key_bindings = load_key_bindings(env)
+
     if env.toolbar:
         # we need to seperate into conditionals otherwise the background for the toolbar will show up
         return prompt_toolkit.prompt(env.get_prompt(),
@@ -54,10 +46,10 @@ def prompt(env, ns): # pylint: disable=invalid-name
                                      completer=ErgonomicaCompleter(ns),
                                      history=HISTORY,
                                      auto_suggest=AutoSuggestFromHistory(),
-                                     key_bindings_registry=key_bindings_registry,
+                                     key_bindings=key_bindings,
     #                                 mouse_support=True,
-                                     get_bottom_toolbar_tokens=lambda cli: [(Token.Toolbar, env.toolbar)],
-                                     get_rprompt_tokens=lambda cli: [(Token, ' '), (Token.RPrompt, env.rprompt)] if env.rprompt else [],
+                                     bottom_toolbar=lambda: [('class:toolbar', env.toolbar)],
+                                     rprompt=lambda: [('', ' '), ('class:rprompt', env.rprompt)] if env.rprompt else [],
                                      style=style)
     else:
         # we need to seperate into conditionals otherwise the background for the toolbar will show up
@@ -66,9 +58,7 @@ def prompt(env, ns): # pylint: disable=invalid-name
                                      completer=ErgonomicaCompleter(ns),
                                      history=HISTORY,
                                      auto_suggest=AutoSuggestFromHistory(),
-                                     key_bindings_registry=key_bindings_registry,
+                                     key_bindings=key_bindings,
     #                                 mouse_support=True,
-                                     get_rprompt_tokens=lambda cli: [(Token, ' '), (Token.RPrompt, env.rprompt)] if env.rprompt else [],
+                                     rprompt=lambda: [('', ' '), ('class:rprompt', env.rprompt)] if env.rprompt else [],
                                      style=style)
-
-

--- a/ergonomica/main.py
+++ b/ergonomica/main.py
@@ -65,6 +65,8 @@ def main():
             # suspended from within Bash with C-z.
             except KeyboardInterrupt:
                 print("[ergo: KeyboardInterrupt]: Exited.")
+            except EOFError:
+                break
 
     elif ('--string' in args) or ('-s' in args):
         for string in args[1:]:


### PR DESCRIPTION
This should do the most important changes for compatibility with prompt_toolkit 2.0, when this is released.
This will also require ptpython 2.0 and pyvim 2.0 (both are also not yet released, but will be released together with prompt_toolkit 2.0).

In the meantime, it could be good to pin the version of both these dependencies on the 1.0 version, so that when prompt_toolkit 2.0 is released, we're not going to break stuff right away.